### PR TITLE
Successful travis build against nightly Rust

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ sudo: required
 language: rust
 rust:
  - stable
+ - beta
+ - nightly
 cache:
 directories:
 - $HOME/.cargo

--- a/src/cassandra/cluster.rs
+++ b/src/cassandra/cluster.rs
@@ -98,7 +98,7 @@ impl FromStr for ContactPoints {
 /// Cassandra cluster that your application interacts with.
 ///
 /// # Examples
-/// ```
+/// ```rust,no_run
 /// use std::str::FromStr;
 /// use cassandra::{Cluster,ContactPoints};
 /// let mut cluster = Cluster::default();

--- a/src/cassandra/cluster.rs
+++ b/src/cassandra/cluster.rs
@@ -103,7 +103,7 @@ impl FromStr for ContactPoints {
 /// use cassandra::{Cluster,ContactPoints};
 /// let mut cluster = Cluster::default();
 /// cluster.set_contact_points(ContactPoints::from_str("127.0.0.1").unwrap()).unwrap();
-/// let mut session = cluster.connect().unwrap();
+/// let session = cluster.connect().unwrap();
 /// ```
 #[derive(Debug)]
 pub struct Cluster(pub *mut _Cluster);

--- a/src/cassandra/cluster.rs
+++ b/src/cassandra/cluster.rs
@@ -1,4 +1,3 @@
-
 #[macro_use]
 use cassandra::future::ConnectFuture;
 use cassandra::policy::retry::RetryPolicy;
@@ -50,8 +49,6 @@ use cassandra_sys::cass_future_error_code;
 use cassandra_sys::cass_session_connect;
 use cassandra_sys::cass_session_new;
 use cassandra_sys::cass_true;
-use errors::*;
-// use ip::IpAddr;
 use errors::*;
 use std::ffi::CString;
 use std::ffi::NulError;


### PR DESCRIPTION
This PR extends the current .travis.yml to support nightly and beta Rust, and includes some minor tweaks required to get nightly to build and test cleanly.

Beta/stable look as if they've been broken by 2c57a8216e26cb7e16d46c2a718b171d5b1d0286, so they are not expected to build cleanly yet. Likewise for the plethora of warnings on nightly.